### PR TITLE
Updating README, update default Cassandra version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ repositories {
 }
 
 dependencies {
-  compile 'org.apache.cassandra:cassandra-all:3.4'
+  compile 'org.apache.cassandra:cassandra-all:3.7'
   compile 'com.ecwid.consul:consul-api:1.1.9'
   compile 'org.apache.commons:commons-collections4:4.0'
   compile 'com.google.guava:guava:19.0'

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,11 @@
 ### Build
 
+Before building, make sure that the Cassandra dependency version matches your version :
+
+	compile 'org.apache.cassandra:cassandra-all:3.7'
+
+Then build: 
+
     gradle shadowJar
     gradle jar
 
@@ -18,7 +24,7 @@ nodes from Consul service catalog.
 
 #### KV
 
-    -Dconsul.kv.disabled=false -Dconsul.kv.prefix='cassandra/seeds'
+    -Dconsul.kv.enabled=true -Dconsul.kv.prefix=cassandra/seeds
 
 
 #### Service


### PR DESCRIPTION
The kv.disabled parameter was wrong.
Also we should not use ' anywhere for parameters.

I think it's also good to udpate the default cassandra-all dependency to 3.7 as this is the last release.
I had weird issue while using the 3.4 with a 3.7 (Everything looked fine except that the Cassandra could not receive any query, even when not using this seed module, that was doing it as soon as the .jar was loaded)