### PR TITLE
Return default seeds if Consul does not return anything

### DIFF
--- a/src/main/java/lt/nkts/cassandra/ConsulSeedProvider.java
+++ b/src/main/java/lt/nkts/cassandra/ConsulSeedProvider.java
@@ -27,8 +27,22 @@ public class ConsulSeedProvider implements SeedProvider {
     private String consul_kv_prefix;
     private String consul_service_name;
     private Collection<String> consul_service_tags;
+    private List<InetAddress> default_seeds;
 
     public ConsulSeedProvider(Map<String, String> args) {
+        // These are used as a fallback if we get nothing from Consul
+        default_seeds = new ArrayList<InetAddress>();
+        String seeds = args.get("seeds");
+        if (seeds != null) {
+            for (String host : Splitter.on(",").trimResults().omitEmptyStrings().split(seeds)) {
+                try {
+                    default_seeds.add(InetAddress.getByName(host));
+                } catch (UnknownHostException ex) {
+                    logger.warn("Seed provider couldn't lookup host " + host);
+                }
+            }
+        }
+
         try {
             consul_url = new URL(System.getProperty("consul.url", "http://localhost:8500/"));
             consul_use_kv = BooleanUtils.toBoolean(System.getProperty("consul.kv.enabled", "false"), "true", "false");
@@ -45,6 +59,7 @@ public class ConsulSeedProvider implements SeedProvider {
         logger.debug("consul_service_tags size [{}]", consul_service_tags.size());
         logger.debug("consul_use_kv {}", consul_use_kv);
         logger.debug("consul_kv_prefix {}", consul_kv_prefix);
+        logger.debug("default_seeds {}", default_seeds);
     }
 
     public List<InetAddress> getSeeds() {
@@ -56,7 +71,7 @@ public class ConsulSeedProvider implements SeedProvider {
             Response response = client.getKVValues(consul_kv_prefix);
             List all = (ArrayList<GetValue>) response.getValue();
             if (all == null) {
-                return Collections.EMPTY_LIST;
+                return Collections.unmodifiableList(default_seeds);
             }
 
             for (Object gv : all) {
@@ -98,11 +113,11 @@ public class ConsulSeedProvider implements SeedProvider {
                 }
             }
         }
-
-        if (seeds.size() > 0) {
-            logger.info("Seeds {}", seeds.toString());
+        if (seeds.isEmpty()) {
+            // We got nothing from Consul so add default seeds
+            seeds.addAll(default_seeds);
         }
-
+        logger.info("Seeds {}", seeds.toString());
         return Collections.unmodifiableList(seeds);
     }
 }


### PR DESCRIPTION
Added a feature to `ConsulSeedProvider` to return default seeds provided in config if Consul does not return any seeds. The default seeds are only returned in case Consul returns an empty list.

This is needed because:
* only one `SeedProvider` can be registered in `cassandra.yaml`, meaning the outputs of multiple `SeedProvider`s cannot easily be chained
* returning empty list from `SeedProvider` prevents Cassandra from starting

This means that when using `ConsulSeedProvider` and there are no other Cassandra nodes registered to Consul, the first Cassandra instance will fail to start. This may be desirable in some situations, but there are also scenarios where it makes sense to start Cassandra with the default seed(s) if there are no other seeds registered to Consul.

This is also the way how other 3rd party `SeedProvider`s, such as [kubernetes-cassandra-seed-provider](https://github.com/glerchundi/kubernetes-cassandra-seed-provider/blob/master/src/io/k8s/cassandra/KubernetesSeedProvider.java#L75-L85), usually do it.

The default seeds parameter is declared the same way as with Cassandra's default `SimpleSeedProvider`, in `cassandra.yaml`:
```yaml
seed_provider:
    - class_name: lt.nkts.cassandra.ConsulSeedProvider
      parameters:
          - seeds: "127.0.0.1"
```